### PR TITLE
feat: add egraph variants to evaluate against propel's workload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 bin/
 target/
 
+.DS_Store
+.backup
+.native
 .idea/
 .idea_modules/
 .settings/

--- a/src/main/scala/propel/evaluator/egraph/EClass.scala
+++ b/src/main/scala/propel/evaluator/egraph/EClass.scala
@@ -1,0 +1,22 @@
+package propel.evaluator.egraph
+
+/** An equivalence class representing a set containing equivalent [[Element]]s. */
+trait EClass extends Element:
+  /** @return the [[ENode]] representative of this [[EClass]]. */
+  def canonical: ENode
+
+/** Companion object of [[EClass]]. */
+object EClass:
+  /** The machine-identifier of an [[EClass]]. */
+  type Id = Element.Id
+
+  /**
+   * @param canonical the specified [[ENode]], representative of this [[EClass]].
+   * @return a new [[EClass]] representing an equivalence class containing the
+   *         specified [[ENode]].
+   */
+  def apply(canonical: ENode): EClass = BasicEClass(canonical)
+
+  /** Basic implementation of [[EClass]]. */
+  private case class BasicEClass(override val canonical: ENode) extends EClass:
+    override final lazy val id: Symbol = canonical.id

--- a/src/main/scala/propel/evaluator/egraph/EClassGenerator.scala
+++ b/src/main/scala/propel/evaluator/egraph/EClassGenerator.scala
@@ -1,0 +1,5 @@
+package propel.evaluator.egraph
+
+/** A function generating [[EClass]]es from [[ENode]]s. */
+@FunctionalInterface 
+trait EClassGenerator extends Function[ENode, EClass]

--- a/src/main/scala/propel/evaluator/egraph/ENode.scala
+++ b/src/main/scala/propel/evaluator/egraph/ENode.scala
@@ -1,0 +1,28 @@
+package propel.evaluator.egraph
+
+/** A node representing an [[Operator]] applied to [[EClass]]es. */
+trait ENode extends Element:
+  /** @return the [[Operator]] applied by this [[ENode]]. */
+  def op: Operator
+  /** @return the [[EClass]] to which [[op]] is applied. */
+  def refs: Seq[EClass]
+  
+/** Companion object of [[ENode]]. */
+object ENode:
+  /** The machine-identifier of an [[ENode]]. */
+  type Id = Element.Id
+
+  /**
+   * @param op the specified [[Operator]].
+   * @param refs the specified [[EClass]]es.
+   * @return a new [[ENode]] representing the specified [[Operator]] applied to the specified [[EClass]]es.
+   */
+  def apply(op: Operator, refs: Seq[EClass] = Seq()): ENode =
+    BasicENode(op, refs)
+
+  /** Basic implementation of [[ENode]]. */
+  private case class BasicENode(override val op: Operator, override val refs: Seq[EClass]) extends ENode:
+    override final lazy val id: Symbol = Symbol({
+      val refsString: String = this.refs.mkString(",")
+      s"$op${if refsString.nonEmpty then s"($refsString)" else ""}"
+    })

--- a/src/main/scala/propel/evaluator/egraph/Element.scala
+++ b/src/main/scala/propel/evaluator/egraph/Element.scala
@@ -1,0 +1,12 @@
+package propel.evaluator.egraph
+
+/** A unique element in the universal set. */
+trait Element:
+  /** @return the identifier of this [[Element]]. */
+  def id: Element.Id
+  override def toString: String = this.id.name
+
+/** Companion object of [[Element]]. */
+object Element:
+  /** The machine-identifier of an [[Element]]. */
+  type Id = Symbol

--- a/src/main/scala/propel/evaluator/egraph/Language.scala
+++ b/src/main/scala/propel/evaluator/egraph/Language.scala
@@ -1,0 +1,96 @@
+package propel.evaluator.egraph
+
+import propel.ast.Pattern.{Bind, Match}
+import propel.ast.Term.{Abs, App, Cases, Data, TypeAbs, TypeApp, Var}
+import propel.ast.{Pattern, Term, Type}
+
+/**
+ * A language for writing terms interpretable by e-graphs.
+ * @tparam T the possible terms in the language.
+ * @note a language depends on a [[EClassGenerator]] to generate [[EClass]]es and
+ *       [[ENode]] from terms. Most of the time, this dependency is actually the
+ *       e-graph to which the language is being adapted. Maybe there is a better
+ *       way to specify this dependency.
+ */
+trait Language[T]:
+  /** An implicit [[Conversion]] from terms to [[ENode]]s. */
+  given termAsEnode(using EClassGenerator): Conversion[T, ENode] = this.parse
+  /** An implicit [[Conversion]] from terms to [[EClass]]es. */
+  given termAsEClass(using EClassGenerator): Conversion[T, EClass] = this.parseClass
+
+  /**
+   * @param term the specified term.
+   * @param generator a function generating [[EClass]]es from [[ENode]]s.
+   * @return the [[ENode]] corresponding to the specified term.
+   */
+  def parse(term: T)(using generator: EClassGenerator): ENode
+  /**
+   * @param term the specified term.
+   * @param generator a function generating [[EClass]]es from [[ENode]]s.
+   * @return the [[EClass]] corresponding to the specified term.
+   */
+  def parseClass(term: T)(using generator: EClassGenerator): EClass = generator(this.parse(term))
+    
+/** Companion object of [[Language]]. */
+object Language:
+  /** An adapter from the language of propel to the language of e-graphs. */
+  object PropelLanguage:
+    /** The set of [[Operator]]s in propel. */
+    object Operators:
+      def Type: Operator = op(":")
+      def Lambda: Operator = op("λ")
+      def TypeLambda(domain: Symbol): Operator = op(s"Λ${domain.name}")
+      def Application: Operator = op("apply")
+      def TypeApplication: Operator = op("applyType")
+      def Constructor: Operator = op("new")
+      def Match: Operator = op("match")
+      def Case: Operator = op("case")
+      private inline def op(name: String): Operator = Operator(s"@$name")
+
+  trait PropelLanguage extends Language[propel.ast.Term]:
+    override def parse(term: Term)(using generator: EClassGenerator): ENode = term match
+      case Abs(properties, ident, tpe, expr) =>
+        ENode(PropelLanguage.Operators.Lambda, Seq(
+          this.parseClass(ident),
+          this.parseClass(expr)
+        ))
+      case TypeAbs(ident, expr) =>
+        ENode(PropelLanguage.Operators.TypeLambda(ident), Seq(
+          this.parseClass(expr)
+        ))
+      case App(properties, expr, arg) =>
+        ENode(PropelLanguage.Operators.Application, Seq(
+          this.parseClass(expr),
+          this.parseClass(arg)
+        ))
+      case TypeApp(expr, tpe) =>
+        ENode(PropelLanguage.Operators.TypeApplication, Seq(
+          this.parseClass(expr),
+          this.parseClass(tpe)
+        ))
+      case Data(ctor, args) =>
+        ENode(Operator(ctor.ident.name), args.map(this.parseClass))
+      case Var(ident) =>
+        ENode(Operator(ident.name))
+      case Cases(scrutinee, cases) =>
+        ENode(PropelLanguage.Operators.Match,
+          this.parseClass(scrutinee) +:
+          cases.map((pattern, term) => generator(
+            ENode(PropelLanguage.Operators.Case, Seq(
+              this.parseClass(pattern),
+              this.parseClass(term)
+            ))
+          ))
+        )
+
+    private def parseClass(id: Symbol)(using generator: EClassGenerator): EClass =
+      generator(ENode(Operator(id.name)))
+      
+    private def parseClass(tpe: Type)(using generator: EClassGenerator): EClass =
+      this.parseClass(Symbol(tpe.toString))
+      
+    private def parseClass(pattern: Pattern)(using generator: EClassGenerator): EClass = pattern match
+      case Match(ctor, args) =>
+        generator(ENode(Operator(ctor.ident.name), args.map(this.parseClass)))
+      case Bind(ident) =>
+        this.parseClass(Symbol(s"?${ident.name}"))

--- a/src/main/scala/propel/evaluator/egraph/Operator.scala
+++ b/src/main/scala/propel/evaluator/egraph/Operator.scala
@@ -1,0 +1,15 @@
+package propel.evaluator.egraph
+
+/** A unique operator. */
+trait Operator(override val id: Symbol) extends Element
+
+/** Companion object of [[Operator]]. */
+object Operator:
+  /**
+   * @param name the name of the operator.
+   * @return a new [[Operator]] with the specified name.
+   */
+  def apply(name: String): Operator = BasicOperator(name)
+
+  /** Basic implementation of [[Operator]]. */
+  private case class BasicOperator(name: String) extends Operator(Symbol(name))

--- a/src/main/scala/propel/evaluator/egraph/mutable/EGraph.scala
+++ b/src/main/scala/propel/evaluator/egraph/mutable/EGraph.scala
@@ -1,0 +1,321 @@
+package propel.evaluator.egraph.mutable
+
+import propel.evaluator.egraph.{EClass, EClassGenerator, ENode, Language, Operator}
+import collection.mutable.{Map as MutableMap, Set as MutableSet}
+
+/** Definition of a mutable egraph. */
+object EGraph:
+  /**
+   * @param other the specified [[EGraph EGraph]].
+   * @return a copy of the specified [[EGraph EGraph]].
+   */
+  def clone(other: EGraph): EGraph =
+    BasicEGraph(
+      underlying = UnionFind.clone(other.underlying),
+      classes = other.classes.clone(),
+      enodes = other.enodes.clone(),
+      datas = other.datas.clone().map(_ -> _.clone()),
+      worklist = other.worklist.clone(),
+      contradictory = other.contradictory,
+    )
+  /** Alias for [[empty]]. */
+  def apply(): EGraph = EGraph.empty
+
+  /** @return an empty e-graph. */
+  def empty: EGraph = BasicEGraph()
+
+  /** An e-graph data structure. */
+  opaque type EGraph = BasicEGraph
+
+  object DisequalityEdges:
+    given EGraphsOps: EGraphOps[EGraph] = new EGraph.DisequalityEdgesOps {}
+
+  object EqualityEmbedding:
+    given EGraphsOps: EGraphOps[EGraph] = new EGraph.EqualityEmbeddingOps {}
+
+  object DisequalityEmbedding:
+    given EGraphsOps: EGraphOps[EGraph] = new EGraph.DisequalityEmbeddingOps {}
+
+
+  /** The mutable data of an [[EClass]]. */
+  private case class EClassData():
+    /** A map from [[ENode]]s referencing this [[EClass]] to their corresponding [[EClass]]. */
+    var uses: MutableMap[ENode, EClass] = MutableMap()
+    /** A set of [[EClass]]es connected to this [[EClass]] by an inequality edge. */
+    var forbids: MutableSet[EClass.Id] = MutableSet()
+    override def clone(): EClassData =
+      val data = EClassData()
+      data.uses = this.uses.clone()
+      data.forbids = this.forbids.clone()
+      data
+
+  /** Basic implementation of an e-graph. */
+  private case class BasicEGraph(
+    underlying: UnionFind.UnionFind[EClass] = UnionFind(),
+    classes: MutableMap[EClass.Id, EClass] = MutableMap(),
+    enodes: MutableMap[ENode, EClass.Id] = MutableMap(),
+    datas: MutableMap[EClass.Id, EClassData] = MutableMap(),
+    worklist: MutableSet[EClass.Id] = MutableSet(),
+    var contradictory: Boolean = false
+  ):
+    override def toString: String =
+      s"""EGraph:
+        | unionfind: $underlying
+        | classes: $classes
+        | enodes: $enodes
+        | datas: $datas
+        | worklist: $worklist
+        | contradictory: $contradictory
+        |""".stripMargin
+
+  /** Basic operations for egraphs. */
+  private trait CommonEGraphOps extends EGraphOps[BasicEGraph]:
+    extension (self: BasicEGraph) {
+      override def eclasses: Map[EClass, Set[ENode]] =
+        self.enodes.groupBy((x, xcId) => self.find(self.classes(xcId))).map(_ -> _.toMap.keySet)
+      override def add(x: ENode): EClass =
+        self.lookup(x) match
+          case (_, Some(xc)) => xc
+          case (x0, _) =>
+            val xc0 = self.find(EClass(x0))
+            x0.refs.foreach(refc =>
+              self.classes.update(refc.id, refc)
+              self.datas.getOrElseUpdate(refc.id, EClassData()).uses.addOne(x0 -> xc0)
+              self.enodes.update(refc.canonical, refc.id)
+            )
+            self.classes.update(xc0.id, xc0)
+            self.datas.update(xc0.id, EClassData())
+            self.enodes.update(x0, xc0.id)
+            xc0
+
+      override def union(xc: EClass, yc: EClass): EClass =
+        val xc0 = self.find(xc)
+        val yc0 = self.find(yc)
+        if xc0 == yc0 then return xc0
+
+        val xyc = self.underlying.union(xc0, yc0)
+        val xycData = self.datas.getOrElseUpdate(xyc.id, EClassData())
+        val other = if xyc.id == xc0.id then yc0 else xc0
+        val otherData = self.datas.getOrElse(other.id, EClassData())
+        xycData.uses.addAll(otherData.uses)
+        self.datas.remove(other.id)
+        self.contradictory ||= self.unequal(xc0, yc0)
+
+        self.worklist.add(xyc.id)
+        xyc
+
+      override def find(xc: EClass): EClass = self.underlying.find(xc)
+
+      override def equal(xc: EClass, yc: EClass): Boolean = self.underlying.congruent(xc, yc)
+
+      override def rebuild(): Unit =
+        def repair(xc: EClass): Unit =
+          val xcData = self.datas.remove(xc.id).getOrElse(EClassData())
+          // Restore universe by making all e-nodes point to canonical e-classes
+          xcData.uses.foreach((x, xcStale) =>
+            self.enodes.remove(x)
+            self.enodes.update(self.canonicalize(x), self.find(xcStale).id)
+          )
+          // Remove duplicate uses
+          val distinctUses = MutableMap[ENode, EClass]()
+          xcData.uses.foreach((x, xcStale) =>
+            val x0 = self.canonicalize(x)
+            distinctUses.get(x0).foreach(xc => self.union(xcStale, xc))
+            distinctUses.update(x0, self.find(xcStale))
+          )
+          xcData.uses = distinctUses
+          self.datas.update(self.find(xc).id, xcData)
+
+        while (self.worklist.nonEmpty) {
+          val brokenClasses = self.worklist.map(id => self.find(self.classes(id)))
+          self.worklist.clear()
+          brokenClasses.foreach(repair)
+        }
+
+      override def canonicalize(x: ENode): ENode = ENode(x.op, x.refs.map(self.find))
+      /**
+       * @param x the specified e-node.
+       * @return a pair containing the specified e-node canonicalized and
+       *         its e-class if already known (i.e., if the e-node was
+       *         already added in the past).
+       */
+      private def lookup(x: ENode): (ENode, Option[EClass]) =
+        val x0 = self.canonicalize(x)
+        (x0, self.enodes.get(x0).map(self.classes))
+    }
+  /** Basic operations for egraphs with disequality edges. */
+  private trait DisequalityEdgesOps extends CommonEGraphOps:
+    extension (self: BasicEGraph) {
+      override def union(xc: EClass, yc: EClass): EClass =
+        val xc0 = self.find(xc)
+        val yc0 = self.find(yc)
+        if xc0 == yc0 then return xc0
+
+        val xyc = self.underlying.union(xc0, yc0)
+        val xycData = self.datas.getOrElseUpdate(xyc.id, EClassData())
+        val other = if xyc.id == xc0.id then yc0 else xc0
+        val otherData = self.datas.getOrElse(other.id, EClassData())
+        xycData.uses.addAll(otherData.uses)
+        xycData.forbids.addAll(otherData.forbids)
+        self.datas.remove(other.id)
+        self.contradictory ||= self.unequal(xc0, yc0)
+
+        self.worklist.add(xyc.id)
+        xyc
+      
+      override def disunion(xc: EClass, yc: EClass): Unit =
+        val xc0 = self.find(xc)
+        val yc0 = self.find(yc)
+        self.datas.getOrElseUpdate(xc0.id, EClassData()).forbids.addOne(yc0.id)
+        self.datas.getOrElseUpdate(yc0.id, EClassData()).forbids.addOne(xc0.id)
+        self.contradictory ||= xc0.id == yc0.id
+
+      override def unequal(xc: EClass, yc: EClass): Boolean =
+        val xc0 = self.find(xc)
+        val yc0 = self.find(yc)
+        val xc0Forbids = self.datas.getOrElse(xc0.id, EClassData()).forbids
+        val yc0Forbids = self.datas.getOrElse(yc0.id, EClassData()).forbids
+        val (smallForbids, large) = if xc0Forbids.size < yc0Forbids.size then (xc0Forbids, yc0) else (yc0Forbids, xc0)
+        smallForbids.map(id => self.find(self.classes(id)).id)(large.id)
+
+      override def hasContradiction: Boolean = self.contradictory
+    }
+
+  /** Basic operations for egraphs with equality embedding. */
+  private trait EqualityEmbeddingOps extends CommonEGraphOps:
+    private val TrueOp: Operator = Operator("@⊤")
+    private val FalseOp: Operator = Operator("@⊥")
+    private val EqualOp: Operator = Operator("@=")
+    private val EmbeddingOps: Set[Operator] = Set(TrueOp, FalseOp, EqualOp)
+    private val True: ENode = ENode(TrueOp)
+    private val False: ENode = ENode(FalseOp)
+    private def Equal(xc: EClass, yc: EClass): ENode = ENode(EqualOp, Seq(xc, yc))
+    private def isEmbedding(x: ENode): Boolean = EmbeddingOps(x.op)
+    
+    extension (self: BasicEGraph){
+      override def add(x: ENode): EClass =
+        val xc = super.add(self)(x)
+        if !EqualityEmbeddingOps.this.isEmbedding(x) then
+          self.underlying.union(self.Equal(xc, xc), self.True)
+        xc
+      override def union(xc: EClass, yc: EClass): EClass =
+        val xc0 = self.find(xc)
+        val yc0 = self.find(yc)
+        if xc0 == yc0 then return xc0
+
+        val xyc = self.underlying.union(xc0, yc0)
+        if !EqualityEmbeddingOps.this.isEmbedding(xc.canonical) then
+          self.underlying.union(self.Equal(xc0, yc0), self.True)
+          self.underlying.union(self.Equal(yc0, xc0), self.True)
+
+        val xycData = self.datas.getOrElseUpdate(xyc.id, EClassData())
+        val other = if xyc.id == xc0.id then yc0 else xc0
+        val otherData = self.datas.getOrElse(other.id, EClassData())
+        xycData.uses.addAll(otherData.uses)
+        self.datas.remove(other.id)
+        self.worklist.add(xyc.id)
+        xyc
+
+      override def disunion(xc: EClass, yc: EClass): Unit =
+        self.underlying.union(self.Equal(xc, yc), self.False)
+        self.underlying.union(self.Equal(yc, xc), self.False)
+      override def unequal(xc: EClass, yc: EClass): Boolean =
+        self.find(self.Equal(xc, yc)) == self.find(self.False)
+      override def hasContradiction: Boolean =
+        self.find(self.True) == self.find(self.False)
+      private def True: EClass = self.add(EqualityEmbeddingOps.this.True)
+      private def False: EClass = self.add(EqualityEmbeddingOps.this.False)
+      private def Equal(xc: EClass, yc: EClass): EClass = self.add(EqualityEmbeddingOps.this.Equal(xc, yc))
+    }
+
+  /** Basic operations for egraphs with disequality embedding. */
+  private trait DisequalityEmbeddingOps extends CommonEGraphOps:
+    private val TrueOp: Operator = Operator("@⊤")
+    private val UnequalOp: Operator = Operator("@≠")
+    private val EmbeddingOps: Set[Operator] = Set(TrueOp, UnequalOp)
+    private val True: ENode = ENode(TrueOp)
+    private def Unequal(xc: EClass, yc: EClass): ENode = ENode(UnequalOp, Seq(xc, yc))
+
+    private def isEmbedding(x: ENode): Boolean = EmbeddingOps(x.op)
+
+    extension (self: BasicEGraph) {
+      override def disunion(xc: EClass, yc: EClass): Unit =
+        self.underlying.union(self.Unequal(xc, yc), self.True)
+        self.underlying.union(self.Unequal(yc, xc), self.True)
+      override def unequal(xc: EClass, yc: EClass): Boolean =
+        self.find(self.Unequal(xc, yc)) == self.find(self.True)
+      override def hasContradiction: Boolean = self.contradictory
+      override def rebuild(): Unit =
+        val hasBeenRebuilt: Boolean = self.worklist.nonEmpty
+        super.rebuild(self)()
+        if hasBeenRebuilt then
+          self.contradictory |= self.enodes.exists((x, xcId) =>
+            x.op == UnequalOp && self.equal(x.refs(0), x.refs(1)) && // if ne(x, x)
+            self.equal(self.classes(xcId), True)                               
+          )
+      private def True: EClass = self.add(DisequalityEmbeddingOps.this.True)
+      private def Unequal(xc: EClass, yc: EClass): EClass = self.add(DisequalityEmbeddingOps.this.Unequal(xc, yc))
+    }
+
+// sbt "runMain propel.evaluator.egraph.mutable.X" where X is one of the following mains
+@main def testDisequalityEdges(): Unit = testEGraph(using EGraph.DisequalityEdges.EGraphsOps)
+@main def testEqualityEmbedding(): Unit = testEGraph(using EGraph.EqualityEmbedding.EGraphsOps)
+@main def testDisequalityEmbedding(): Unit = testEGraph(using EGraph.DisequalityEmbedding.EGraphsOps)
+
+def testEGraph(using EGraphOps[EGraph.EGraph]): Unit =
+  /** Define your own simple language */
+  trait Exp
+  case class Fun(fnId: String) extends Exp:
+    def apply(args: Exp*): App = App(this, args)
+    override def toString: String = fnId
+  case class App(fn: Fun, args: Seq[Exp] = Seq()) extends Exp:
+    override def toString: String = s"$fn(${args.mkString(",")})"
+  
+  object SimpleLanguage extends Language[Exp]:
+    override def parse(term: Exp)(using EClassGenerator): ENode = term match
+      case Fun(fnId) => ENode(Operator(fnId))
+      case App(fn, args) => ENode(Operator("apply"), (fn +: args).map(this.parseClass))
+
+  /** Test the egraph implementation on that language */
+  val egraph = EGraph()
+
+  import SimpleLanguage.given         // Implicit conversions for using Exps directly, instead of ENodes and EClasses
+  given EClassGenerator = egraph.add  // Enable the conversions by providing a way to create EClasses
+  import scala.language.implicitConversions
+
+  val (a,b,c,d,e,f,g,h,i) = (Fun("a"), Fun("b"), Fun("c"), Fun("d"), Fun("e"), Fun("f"), Fun("g"), Fun("h"), Fun("i"))
+  val fa = egraph.add(f(a))
+  val fb = egraph.add(f(b))
+  egraph.add(f(a,b,c,d,e,f,g))
+  egraph.union(a, b)
+  egraph.union(c, d)
+  egraph.union(e, f)
+  egraph.union(c, b)
+  egraph.add(h)
+
+  val egraph2 = EGraph.clone(egraph)
+  egraph2.rebuild()
+
+  egraph.disunion(f(a), f(b))
+  egraph.rebuild()
+
+  println("\nCANONICALIZATION:")
+  println(Seq(a, b, f(a), f(b)).map(e => s"$e: ${egraph.find(e)}").mkString("; "))
+  println(s"canonicalize(${f(b)}): ${egraph.canonicalize(f(b))}")
+  println(s"canonicalize(${f(b)}): ${egraph2.canonicalize(f(b))}")
+
+  println("\nECLASSES")
+  println(s"eclasses: ${egraph.eclasses}")
+  println(s"# eclasses: ${egraph.eclasses.size}")
+  println(s"# enodes: ${egraph.eclasses.foldLeft(0)(_ + _._2.size)}")
+  println(s"eclasses: ${egraph2.eclasses}")
+  println(s"# eclasses: ${egraph2.eclasses.size}")
+  println(s"# enodes: ${egraph2.eclasses.foldLeft(0)(_ + _._2.size)}")
+
+  println("\nCONTRADICTION:")
+  println(s"${f(a)} == ${f(b)}: ${egraph.equal(f(a), f(b))}")
+  println(s"${f(a)} != ${f(b)}: ${egraph.unequal(f(a), f(b))}")
+  println(s"hasContradiction: ${egraph.hasContradiction}")
+  println(s"${f(a)} == ${f(b)}: ${egraph2.equal(f(a), f(b))}")
+  println(s"${f(a)} != ${f(b)}: ${egraph2.unequal(f(a), f(b))}")
+  println(s"hasContradiction: ${egraph2.hasContradiction}")

--- a/src/main/scala/propel/evaluator/egraph/mutable/EGraphOps.scala
+++ b/src/main/scala/propel/evaluator/egraph/mutable/EGraphOps.scala
@@ -1,0 +1,65 @@
+package propel.evaluator.egraph.mutable
+
+import propel.evaluator.egraph.{EClass, ENode}
+
+/** A type-class defining the operations supported by an e-graph. */
+trait EGraphOps[EGraph]:
+  extension (self: EGraph) {
+    /** @return a map from [[EClass]]es to the sets of their [[ENode]]es. */
+    def eclasses: Map[EClass, Set[ENode]]
+    /**
+     * Add the specified [[ENode]] to this e-graph.
+     * @param x the specified [[ENode]].
+     * @return the [[EClass]] of the specified [[ENode]].
+     * @note the hash-cons invariant may be broken after a call
+     *       to this method.
+     */
+    def add(x: ENode): EClass
+    /**
+     * Merge the specified [[EClass]]es into a new [[EClass]].
+     * @param xc the first specified [[EClass]].
+     * @param yc the second specified [[EClass]].
+     * @return the new [[EClass]].
+     * @note the hash-cons and congruence invariants may be broken
+     *       after a call to this method.
+     */
+    def union(xc: EClass, yc: EClass): EClass
+    /**
+     * Add a inequality edge between the two specified [[EClass]]es.
+     * @param xc the first specified [[EClass]].
+     * @param yc the second specified [[EClass]].
+     */
+    def disunion(xc: EClass, yc: EClass): Unit
+    /**
+     * @param xc the specified [[EClass]].
+     * @return the canonical [[EClass]] representing the specified
+     *         [[EClass]].
+     */
+    def find(xc: EClass): EClass
+    /**
+     * @param xc the first specified [[EClass]].
+     * @param yc the second specified [[EClass]].
+     * @return [[true]] if the two specified [[EClass]]es are equivalent;
+     *         [[false]] otherwise.
+     */
+    def equal(xc: EClass, yc: EClass): Boolean
+    /**
+     * @param xc the first specified [[EClass]].
+     * @param yc the second specified [[EClass]].
+     * @return [[true]] if there exist a inequality edge between the
+     *         two specified [[EClass]]es; [[false]] otherwise.
+     */
+    def unequal(xc: EClass, yc: EClass): Boolean
+    /** Restore the hash-cons and congruence invariance in this e-graph. */
+    def rebuild(): Unit
+    /**
+     * @param x the specified [[ENode]].
+     * @return an equivalent [[ENode]] referencing only canonical [[EClass]]es.
+     */
+    def canonicalize(x: ENode): ENode
+    /** 
+     * @return [[true]] if any two [[EClass]]es are both [[equal]] and [[unequal]];
+     *         [[false]] otherwise.
+     */
+    def hasContradiction: Boolean
+  }

--- a/src/main/scala/propel/evaluator/egraph/mutable/UnionFind.scala
+++ b/src/main/scala/propel/evaluator/egraph/mutable/UnionFind.scala
@@ -1,0 +1,104 @@
+package propel.evaluator.egraph.mutable
+
+import propel.evaluator.egraph.Element
+
+import collection.mutable.{Map as MutableMap, Set as MutableSet}
+
+/** Definition of a mutable unionfind. */
+object UnionFind:
+  /**
+   * @param other the specified [[UnionFind UnionFind]].
+   * @tparam E the type of elements of the specified [[UnionFind UnionFind]].
+   * @return a copy of the specified [[UnionFind UnionFind]].
+   */
+  def clone[E <: Element](other: UnionFind[E]): UnionFind[E] =
+    BasicUnionFind(
+      universeMap = other.universeMap.clone(),
+      parentMap = other.parentMap.clone(),
+      heightMap = other.heightMap.clone()
+    )
+  /** Alias for [[empty]]. */
+  def apply[E <: Element](): UnionFind[E] = UnionFind.empty[E]
+  /**
+   * @tparam E the specified type of [[Element]]s.
+   * @return an empty union-find for the specified type of [[Element]]s.
+   */
+  def empty[E <: Element]: UnionFind[E] = BasicUnionFind[E]()
+
+  /** A union-find data structure. */
+  opaque type UnionFind[E <: Element] = BasicUnionFind[E]
+  given UnionFindOps: UnionFindOps[UnionFind] = BasicUnionFindOps
+
+  /** Basic implementation of a union-find based on hash-consing. */
+  private case class BasicUnionFind[E <: Element](
+    universeMap: MutableMap[Element.Id, E] = MutableMap[Element.Id, E](),
+    parentMap: MutableMap[Element.Id, Element.Id] = MutableMap(),
+    heightMap: MutableMap[Element.Id, Int] = MutableMap()
+  ):
+    override def toString: String =
+      s"""UnionFind:
+        | universe: ${universeMap.values}
+        | parents: $parentMap
+        | heights: $heightMap
+        |""".stripMargin
+
+  private given BasicUnionFindOps: UnionFindOps[BasicUnionFind] with
+    extension[E <: Element](self: BasicUnionFind[E]) {
+      override def universe: Set[E] = self.universeMap.values.toSet
+
+      override def union(x: E, y: E): E =
+        val x0 = self.find(x)
+        val y0 = self.find(y)
+        // always put the shortest tree under the tallest tree when merging
+        if self.heightMap(x0.id) >= self.heightMap(y0.id)
+        then self.setParent(y0, x0)
+        else self.setParent(x0, y0)
+
+      override def find(x: E): E =
+        self.parentMap.get(x.id) match
+          // x is canonical --> return x
+          case Some(xParentId) if x.id == xParentId => x
+          // x has a parent --> recurse on the parent and compress the tree
+          case Some(xParentId) =>
+            self.setParent(x, self.find(self.universeMap(xParentId)))
+          // x is a new element --> set x as canonical and return it
+          case _ =>
+            self.universeMap.update(x.id, x)
+            self.parentMap.update(x.id, x.id)
+            self.heightMap.update(x.id, 0)
+            x
+
+      override def congruent(x: E, y: E): Boolean = self.find(x).id == self.find(y).id
+
+      /**
+       * Set the parent of the specified child [[Element]] to the
+       * specified parent [[Element]].
+       * @param child the specified child [[Element]].
+       * @param parent the specified parent [[Element]].
+       * @return the specified parent [[Element]].
+       */
+      private inline def setParent(child: E, parent: E): E =
+        val ch = self.heightMap(child.id)
+        val ph = self.heightMap(parent.id)
+        self.parentMap.update(child.id, parent.id)
+        if ch >= ph then self.heightMap.update(parent.id, ch + 1)
+        parent
+    }
+
+// sbt "runMain propel.evaluator.egraph.mutable.testUnionFind"
+@main def testUnionFind(): Unit =
+  /** Define your own universe set. */
+  case class E(name: String) extends Element:
+    override def id: Element.Id = Symbol(name)
+
+  /** Test the unionfind implementation on that set */
+  val uf = UnionFind[E]()
+  val (a, b, c, d, e, f, g, h) = (E("a"), E("b"), E("c"), E("d"), E("e"), E("f"), E("g"), E("h"))
+  uf.union(a, b)
+  uf.union(b, f)
+  uf.union(f, g)
+  uf.union(h, h)
+  uf.union(c, d)
+  uf.union(b, e)
+  println(Seq(a, b, c, d, e, f, g, h).map(uf.find).mkString(" "))
+  println(uf)

--- a/src/main/scala/propel/evaluator/egraph/mutable/UnionFindOps.scala
+++ b/src/main/scala/propel/evaluator/egraph/mutable/UnionFindOps.scala
@@ -1,0 +1,30 @@
+package propel.evaluator.egraph.mutable
+
+import propel.evaluator.egraph.Element
+
+/** A type-class defining the operations supported by a union-find. */
+trait UnionFindOps[UnionFind[_ <: Element]]:
+  extension[E <: Element] (self: UnionFind[E]) {
+    /** @return the set of all known [[Element]]s. */
+    def universe: Set[E]
+    /**
+     * Merge the partitions of the two specified [[Element]]s into a new partition.
+     * @param x the first specified [[Element]].
+     * @param y the second specified [[Element]].
+     * @return the canonical [[Element]] of the new partition.
+     */
+    def union(x: E, y: E): E
+    /**
+     * @param x the specified [[Element]].
+     * @return the canonical [[Element]] of the partition to which the specified
+     *         [[Element]] belongs.
+     */
+    def find(x: E): E
+    /**
+     * @param x the first specified [[Element]].
+     * @param y the second specified [[Element]].
+     * @return [[true]] if the specified [[Element]]s belong to the same partition;
+     *         [[false]] otherwise.
+     */
+    def congruent(x: E, y: E): Boolean
+  }

--- a/src/main/scala/propel/evaluator/symbolic.scala
+++ b/src/main/scala/propel/evaluator/symbolic.scala
@@ -542,7 +542,10 @@ object Symbolic:
                 makeResult(reductions) -> reductionsControl
     end eval
 
-    Result(init.reductions flatMap { case Reduction(expr, constraints, equalities) =>
+    // TODO: change so that consumed equalities are added to the egraph statistics
+    //       DONE
+    import EGraphEqualities.EGraphStats
+    val result = Result(init.reductions flatMap { case Reduction(expr, constraints, equalities) =>
       constraintsFromEqualities(constraints, equalities, constsCache) match
         case (Some(constraints, equalities)) =>
           val normalized = normalize(expr, equalities, config, exprCache)
@@ -573,5 +576,7 @@ object Symbolic:
         case _ =>
           List.empty
     })
+    result.reductions.foreach(r => EGraphStats.Global = EGraphStats.Global :+ EGraphStats.fromEqualities(r.equalities))
+    result
   end eval
 end Symbolic


### PR DESCRIPTION
# Artifact for POPL'25

## Description
Added 3 egraph variants for encoding disequalities: DE (Disequality Edges), EE (Equality Embedding), and NEE (Disequality Embedding). These egraph variants have been integrated with Propel, monitoring the discovery of equalities, evaluating equalities between terms, and checking for contradictions.

## Notes
The implementation is not fully optimized for inductive theorem proving, but simply acts as an evaluation of different variants of egraphs against the typical workload of inductive theorem proving.